### PR TITLE
Normalize DFT and add sync correlation test

### DIFF
--- a/search.py
+++ b/search.py
@@ -28,7 +28,8 @@ def dft_mag(
     angle = -2j * math.pi * freq_in_hz / sample_rate
     segment = samples[start_dt_in_samples : start_dt_in_samples + length_in_samples]
     exps = np.exp(angle * n)
-    return abs(np.dot(segment, exps))
+    # Normalize the DFT magnitude so a unit amplitude tone produces 1.0
+    return abs(np.dot(segment, exps)) / float(length_in_samples)
 
 
 def find_candidates(

--- a/tests/test_candidate_search.py
+++ b/tests/test_candidate_search.py
@@ -16,13 +16,13 @@ def test_candidate_search(tmp_path):
         audio,
         freq_range,
         dt_range,
-        threshold=4.0,
+        threshold=0.002,
     )
     assert candidates, "no candidates found"
     score, dt, freq = candidates[0]
     assert abs(freq - 1500) < 1.0
     assert abs(dt - 0.0) < 0.2
-    assert score > 4.0
+    assert score > 0.002
     for _, _, f in candidates:
         assert abs(f - 1500) <= 32
 
@@ -37,5 +37,5 @@ def test_candidate_search_noise():
     num_samples = dt_range[-1] + sym_len * 7
     noise = [random.uniform(-1e-2, 1e-2) for _ in range(num_samples)]
     noise_audio = RealSamples(noise, sample_rate_in_hz)
-    cands = find_candidates(noise_audio, freq_range, dt_range, threshold=4.0)
+    cands = find_candidates(noise_audio, freq_range, dt_range, threshold=0.002)
     assert not cands

--- a/tests/test_sync_correlation.py
+++ b/tests/test_sync_correlation.py
@@ -1,0 +1,32 @@
+import math
+import numpy as np
+
+from search import dft_mag
+from utils import COSTAS_SEQUENCE, TONE_SPACING_IN_HZ, RealSamples
+
+
+def test_perfect_sync_correlation():
+    sample_rate = 12000
+    base_freq = 1500
+    sym_len = int(round(sample_rate / TONE_SPACING_IN_HZ))
+    start = int(sample_rate * 0.5)
+    total_len = start + sym_len * len(COSTAS_SEQUENCE)
+    samples = np.zeros(total_len)
+
+    for idx, tone in enumerate(COSTAS_SEQUENCE):
+        freq = base_freq + tone * TONE_SPACING_IN_HZ
+        n = np.arange(sym_len)
+        wave = 2 * np.cos(2 * math.pi * freq * n / sample_rate)
+        sstart = start + idx * sym_len
+        samples[sstart : sstart + sym_len] = wave
+
+    audio = RealSamples(samples, sample_rate)
+
+    score = 0.0
+    for idx, tone in enumerate(COSTAS_SEQUENCE):
+        freq = base_freq + tone * TONE_SPACING_IN_HZ
+        sstart = start + idx * sym_len
+        score += dft_mag(audio.samples, audio.sample_rate_in_hz, sstart, freq, sym_len)
+
+    correlation = score / len(COSTAS_SEQUENCE)
+    assert abs(correlation - 1.0) < 1e-6


### PR DESCRIPTION
## Summary
- normalize `dft_mag` by the window length
- adjust candidate search tests for new scale
- add regression test verifying a perfect sync sequence yields correlation 1.0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686380ab10dc8327bc3cc404a71a5470