### PR TITLE
Use FFT for candidate search

### DIFF
--- a/tests/test_sync_correlation.py
+++ b/tests/test_sync_correlation.py
@@ -1,32 +1,37 @@
-import math
 import numpy as np
 
-from search import dft_mag
-from utils import COSTAS_SEQUENCE, TONE_SPACING_IN_HZ, RealSamples
+from search import find_candidates
+from utils import (
+    COSTAS_SEQUENCE,
+    TONE_SPACING_IN_HZ,
+    COSTAS_START_OFFSET_SEC,
+    RealSamples,
+)
+from tests.utils import default_search_params
 
 
-def test_perfect_sync_correlation():
+def test_perfect_sync_detection():
     sample_rate = 12000
     base_freq = 1500
-    sym_len = int(round(sample_rate / TONE_SPACING_IN_HZ))
-    start = int(sample_rate * 0.5)
+    sym_len = int(sample_rate / TONE_SPACING_IN_HZ)
+    start = int(sample_rate * COSTAS_START_OFFSET_SEC)
     total_len = start + sym_len * len(COSTAS_SEQUENCE)
     samples = np.zeros(total_len)
 
     for idx, tone in enumerate(COSTAS_SEQUENCE):
         freq = base_freq + tone * TONE_SPACING_IN_HZ
         n = np.arange(sym_len)
-        wave = 2 * np.cos(2 * math.pi * freq * n / sample_rate)
+        wave = 2 * np.cos(2 * np.pi * freq * n / sample_rate)
         sstart = start + idx * sym_len
         samples[sstart : sstart + sym_len] = wave
 
     audio = RealSamples(samples, sample_rate)
+    max_freq_bin, max_dt_symbols = default_search_params(sample_rate)
+    candidates = find_candidates(audio, max_freq_bin, max_dt_symbols, threshold=0.1)
+    assert candidates
+    score, dt, freq = candidates[0]
+    expected_dt = (start // sym_len) * sym_len / sample_rate - COSTAS_START_OFFSET_SEC
+    assert abs(freq - base_freq) < 1.0
+    assert abs(dt - expected_dt) < 1e-6
+    assert score > 0
 
-    score = 0.0
-    for idx, tone in enumerate(COSTAS_SEQUENCE):
-        freq = base_freq + tone * TONE_SPACING_IN_HZ
-        sstart = start + idx * sym_len
-        score += dft_mag(audio.samples, audio.sample_rate_in_hz, sstart, freq, sym_len)
-
-    correlation = score / len(COSTAS_SEQUENCE)
-    assert abs(correlation - 1.0) < 1e-6

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,3 +16,14 @@ def generate_ft8_wav(message: str, workdir: Path, freq: int = 1500) -> Path:
     ]
     subprocess.run(cmd, cwd=workdir, check=True, stdout=subprocess.PIPE, text=True)
     return workdir / "000000_000001.wav"
+
+
+def default_search_params(sample_rate_in_hz: int):
+    """Return ``(max_freq_bin, max_dt_symbols)`` used for candidate searches."""
+    from utils import TONE_SPACING_IN_HZ
+
+    sym_len = int(sample_rate_in_hz / TONE_SPACING_IN_HZ)
+    max_freq_bin = int(2500 / TONE_SPACING_IN_HZ)
+    max_dt_samples = int(sample_rate_in_hz * 2)
+    max_dt_symbols = max_dt_samples // sym_len
+    return max_freq_bin, max_dt_symbols

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,6 +17,13 @@ TONE_SPACING_IN_HZ = 6.25
 # start times so they line up with timestamps reported by WSJT‑X.
 COSTAS_START_OFFSET_SEC = 0.5
 
+# Duration of a single FT8 symbol in seconds.  Each symbol lasts for the
+# reciprocal of the tone spacing.
+FT8_SYMBOL_LENGTH_IN_SEC = 1.0 / TONE_SPACING_IN_HZ
+
+# Number of symbols that make up a full FT8 message.
+FT8_SYMBOLS_PER_MESSAGE = 79
+
 
 @dataclass
 class RealSamples:
@@ -55,4 +62,6 @@ __all__ = [
     "COSTAS_SEQUENCE",
     "TONE_SPACING_IN_HZ",
     "COSTAS_START_OFFSET_SEC",
+    "FT8_SYMBOL_LENGTH_IN_SEC",
+    "FT8_SYMBOLS_PER_MESSAGE",
 ]


### PR DESCRIPTION
## Summary
- rename oversampling constant and expand Costas bins
- pad FFT windows using oversampling ratio
- drop unused `dft_mag` helper from library and inline it in tests
- iterate directly over frequency bins during candidate search
- address review comments:
  - improve naming and docs
  - factor search defaults for tests
  - add FT8 symbol constants
  - rewrite sync correlation test to use candidate search

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863f75b0ff483278c90c9b5a4a216a7