### PR TITLE
Use consistent search threshold

### DIFF
--- a/demod.py
+++ b/demod.py
@@ -1,0 +1,74 @@
+import numpy as np
+from typing import List, Tuple
+
+from utils import (
+    RealSamples,
+    TONE_SPACING_IN_HZ,
+    COSTAS_START_OFFSET_SEC,
+    FT8_SYMBOL_LENGTH_IN_SEC,
+    FT8_SYMBOLS_PER_MESSAGE,
+)
+
+# Symbol positions occupied by the three 7-symbol Costas sequences.
+COSTAS_POSITIONS = list(range(7)) + list(range(36, 43)) + list(range(72, 79))
+
+
+# Map tone indices to 3-bit values using Gray coding.
+GRAY_MAP = [
+    0b000,  # tone 0
+    0b001,  # tone 1
+    0b011,  # tone 2
+    0b010,  # tone 3
+    0b110,  # tone 4
+    0b100,  # tone 5
+    0b101,  # tone 6
+    0b111,  # tone 7
+]
+
+
+def naive_demod(samples_in: RealSamples, freq: float, dt: float) -> Tuple[str, List[int]]:
+    """Very naive FT8 demodulator.
+
+    Parameters
+    ----------
+    samples_in:
+        Input audio samples with sample rate.
+    freq:
+        Base frequency in Hz returned by :func:`search.find_candidates`.
+    dt:
+        Start time offset from :func:`search.find_candidates`.
+
+    Returns
+    -------
+    Tuple[str, List[int]]
+        Bit string for the message payload and list of tone indices.
+    """
+    samples = samples_in.samples
+    sample_rate = samples_in.sample_rate_in_hz
+    sym_len = int(round(sample_rate * FT8_SYMBOL_LENGTH_IN_SEC))
+    # ``dt`` comes from ``find_candidates`` which subtracts
+    # ``COSTAS_START_OFFSET_SEC`` from the true signal start time.
+    # Add it back here and convert to a sample index.
+    start = int(round((dt + COSTAS_START_OFFSET_SEC) * sample_rate))
+    time_idx = np.arange(sym_len) / sample_rate
+    bases = np.exp(
+        -2j
+        * np.pi
+        * (freq + np.arange(8) * TONE_SPACING_IN_HZ)[:, None]
+        * time_idx
+    )
+
+    tones: List[int] = []
+    for sym in range(FT8_SYMBOLS_PER_MESSAGE):
+        seg = samples[start + sym * sym_len : start + (sym + 1) * sym_len]
+        assert len(seg) == sym_len, "ran out of samples"
+        tones.append(int(np.argmax(np.abs(np.matmul(bases, seg)))))
+
+    bits: List[str] = []
+    for idx, tone in enumerate(tones):
+        if idx in COSTAS_POSITIONS:
+            continue
+        val = GRAY_MAP[tone]
+        bits.append(f"{val:03b}")
+    bitstring = "".join(bits)
+    return bitstring, tones

--- a/tests/test_ft8_wsjt.py
+++ b/tests/test_ft8_wsjt.py
@@ -1,7 +1,11 @@
 import subprocess
 from pathlib import Path
 
-from tests.utils import generate_ft8_wav
+from tests.utils import (
+    generate_ft8_wav,
+    DEFAULT_FREQ_EPS,
+    DEFAULT_DT_EPS,
+)
 
 
 def decode_ft8_wav(path: Path) -> str:
@@ -36,6 +40,6 @@ def test_ft8sim_to_jt9(tmp_path):
 
     assert decoded_msg == msg
     assert abs(snr - (-10)) <= 1.0
-    assert abs(dt - 0.0) < 0.2
+    assert abs(dt - 0.0) < DEFAULT_DT_EPS
     assert abs(freq - 1500) < 2.0
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,23 @@
 from pathlib import Path
 import subprocess
 
+DEFAULT_SEARCH_THRESHOLD = 0.001
 
-def generate_ft8_wav(message: str, workdir: Path, freq: int = 1500) -> Path:
+# Epsilon for validating decoded frequency in tests (Hz)
+DEFAULT_FREQ_EPS = 1.0
+# Epsilon for validating decoded time offset in tests (s)
+DEFAULT_DT_EPS = 0.2
+
+
+def generate_ft8_wav(
+    message: str,
+    workdir: Path,
+    freq: int = 1500,
+    snr: int = -10,
+) -> Path:
     """Run ft8sim to generate a WAV file containing ``message``."""
+
+    snr_for_ft8sim = snr
     cmd = [
         "ft8sim",
         message,
@@ -12,10 +26,38 @@ def generate_ft8_wav(message: str, workdir: Path, freq: int = 1500) -> Path:
         "0",
         "0",
         "1",
-        "-10",
+        str(snr_for_ft8sim),
     ]
     subprocess.run(cmd, cwd=workdir, check=True, stdout=subprocess.PIPE, text=True)
     return workdir / "000000_000001.wav"
+
+
+def ft8code_bits(message: str) -> str:
+    """Return the 174-bit FT8 payload for ``message`` using ``ft8code``."""
+    result = subprocess.run(
+        ["ft8code", message], check=True, stdout=subprocess.PIPE, text=True
+    )
+    bits = []
+    grab = False
+    for line in result.stdout.splitlines():
+        if "Source-encoded message" in line:
+            grab = True
+            continue
+        if grab and line.strip():
+            bits.append(line.strip())
+            if len("".join(bits)) >= 77:
+                grab = False
+        if "14-bit CRC:" in line:
+            grab = True
+            continue
+        if "83 Parity bits:" in line:
+            grab = True
+            continue
+        if grab and line.strip():
+            bits.append(line.strip())
+            if len("".join(bits)) >= 174:
+                break
+    return "".join(bits)[:174]
 
 
 def default_search_params(sample_rate_in_hz: int):


### PR DESCRIPTION
## Summary
- centralize test constants in `tests/utils.py`
- expect non-zero mismatches at lower SNR
- ensure candidate search tests use the shared constants
- remove unused frequency range constant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643abf26e88327a001f9e413359066