### PR TITLE
Add baseband downsample utility

### DIFF
--- a/tests/test_candidate_search.py
+++ b/tests/test_candidate_search.py
@@ -7,7 +7,7 @@ from utils import (
     FT8_SYMBOLS_PER_MESSAGE,
     check_crc,
 )
-from demod import soft_demod, naive_hard_decode
+from demod import soft_demod, naive_hard_decode, downsample_to_baseband
 import random
 
 from tests.utils import (
@@ -58,7 +58,8 @@ def test_naive_demod(tmp_path):
     max_freq_bin, max_dt_symbols = default_search_params(audio.sample_rate_in_hz)
     cand = find_candidates(audio, max_freq_bin, max_dt_symbols, threshold=DEFAULT_SEARCH_THRESHOLD)[0]
     _, dt, freq = cand
-    llrs = soft_demod(audio, freq, dt)
+    bb = downsample_to_baseband(audio, freq)
+    llrs = soft_demod(bb, 0.0, dt)
     decoded_bits = naive_hard_decode(llrs)
     expected_bits = ft8code_bits(msg)
     assert decoded_bits == expected_bits
@@ -74,7 +75,8 @@ def test_naive_demod_low_snr(tmp_path):
         audio, max_freq_bin, max_dt_symbols, threshold=DEFAULT_SEARCH_THRESHOLD
     )[0]
     _, dt, freq = cand
-    llrs = soft_demod(audio, freq, dt)
+    bb = downsample_to_baseband(audio, freq)
+    llrs = soft_demod(bb, 0.0, dt)
     decoded_bits = naive_hard_decode(llrs)
     expected_bits = ft8code_bits(msg)
     mismatches = sum(a != b for a, b in zip(decoded_bits, expected_bits))

--- a/tests/test_ldpc_decode.py
+++ b/tests/test_ldpc_decode.py
@@ -1,5 +1,5 @@
 import numpy as np
-from demod import ldpc_decode, soft_demod, naive_hard_decode
+from demod import ldpc_decode, soft_demod, naive_hard_decode, downsample_to_baseband
 from search import find_candidates
 from utils import read_wav, check_crc
 from tests.utils import (
@@ -19,7 +19,8 @@ def test_ldpc_decode_runs(tmp_path):
         audio, max_freq_bin, max_dt_symbols, threshold=DEFAULT_SEARCH_THRESHOLD
     )[0]
     _, dt, freq = cand
-    llrs = soft_demod(audio, freq, dt)
+    bb = downsample_to_baseband(audio, freq)
+    llrs = soft_demod(bb, 0.0, dt)
     naive_bits = naive_hard_decode(llrs)
     decoded = ldpc_decode(llrs)
     expected = ft8code_bits(msg)

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -66,6 +66,18 @@ class RealSamples:
         self.samples = np.asarray(self.samples, dtype=float)
 
 
+@dataclass
+class ComplexSamples:
+    """Container for complex-valued samples and their sampling rate."""
+
+    samples: np.ndarray
+    sample_rate_in_hz: int
+
+    def __post_init__(self) -> None:
+        """Ensure that ``samples`` is a NumPy ``complex`` array."""
+        self.samples = np.asarray(self.samples, dtype=complex)
+
+
 def read_wav(path: str) -> RealSamples:
     """Load mono PCM WAV data and return a :class:`RealSamples` object."""
     with wave.open(path, "rb") as w:
@@ -87,6 +99,7 @@ def read_wav(path: str) -> RealSamples:
 
 __all__ = [
     "RealSamples",
+    "ComplexSamples",
     "read_wav",
     "COSTAS_SEQUENCE",
     "TONE_SPACING_IN_HZ",


### PR DESCRIPTION
## Summary
- add `ComplexSamples` container
- implement `downsample_to_baseband` for extracting a narrow band
- use downsampled audio for tests
- refine variable naming and constant definitions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b18c70a9c8327ac84c9354d7ee66f