### PR TITLE
Stop checking SNR in E2E tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ pytest -q
 ```
 
 The test uses `ft8sim` to create a `.wav` file and decodes it with `jt9`.
-It verifies that the decoded message and reported SNR, frequency and
+It verifies that the decoded message along with the reported frequency and
 time offset closely match the values used to generate the sample.

--- a/tests/test_ft8_wsjt.py
+++ b/tests/test_ft8_wsjt.py
@@ -24,11 +24,10 @@ def decode_ft8_wav(path: Path) -> str:
 def parse_jt9_output(line: str):
     """Return decoded parameters from a jt9 output line."""
     parts = line.split(maxsplit=5)
-    snr = float(parts[1])
     dt = float(parts[2])
     freq = float(parts[3])
     message = parts[5].strip()
-    return snr, dt, freq, message
+    return dt, freq, message
 
 
 def test_ft8sim_to_jt9(tmp_path):
@@ -36,10 +35,9 @@ def test_ft8sim_to_jt9(tmp_path):
     wav_path = generate_ft8_wav(msg, tmp_path)
     output = decode_ft8_wav(wav_path)
     first_line = output.splitlines()[0]
-    snr, dt, freq, decoded_msg = parse_jt9_output(first_line)
+    dt, freq, decoded_msg = parse_jt9_output(first_line)
 
     assert decoded_msg == msg
-    assert abs(snr - (-10)) <= 1.0
     assert abs(dt - 0.0) < DEFAULT_DT_EPS
     assert abs(freq - 1500) < 2.0
 


### PR DESCRIPTION
## Summary
- update README about tests
- drop SNR check from `test_ft8_wsjt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eab8e805883279db0cfbeed0f5405