### PR TITLE
Improve FT8 frequency sync

### DIFF
--- a/demod.py
+++ b/demod.py
@@ -188,7 +188,11 @@ def fine_sync_candidate(
     bb = downsample_to_baseband(samples_in, freq)
 
     dt = fine_time_sync(bb, dt, 10)
-    df = fine_freq_sync(bb, dt, 2.5, 0.5)
+    # ``find_candidates`` only locates frequencies to the nearest FT8 tone
+    # spacing (6.25 Hz).  Some of the test samples include signals that fall
+    # roughly halfway between these coarse bins.  Increase the fine frequency
+    # search span and resolution so such offsets can be recovered.
+    df = fine_freq_sync(bb, dt, 5.0, 0.25)
     freq += df
 
     bb = downsample_to_baseband(samples_in, freq)

--- a/tests/test_sample_wavs.py
+++ b/tests/test_sample_wavs.py
@@ -14,13 +14,13 @@ DATA_DIR = Path(__file__).resolve().parent.parent / "ft8_lib-2.0" / "test" / "wa
 # listed transmissions we currently expect to miss.  Additional decodes not
 # present in the ``.txt`` file are ignored by the assertions below.
 SAMPLES = {
-    "191111_110115": (0, 1),
+    "191111_110115": (1, 0),
     "191111_110130": (4, 1),
-    "191111_110145": (0, 1),
+    "191111_110145": (1, 0),
     "191111_110200": (3, 2),
     "191111_110215": (2, 1),
     "191111_110615": (15, 6),
-    "191111_110630": (8, 6),
+    "191111_110630": (10, 4),
     "191111_110645": (15, 4),
     "191111_110700": (12, 3),
 }


### PR DESCRIPTION
## Summary
- widen frequency search span and resolution during fine sync
- update expected decode counts for sample WAVs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f25a020448327954849313b520291