### PR TITLE
Add separate single and multi-pass sample tests

### DIFF
--- a/tests/test_multipass_decoding.py
+++ b/tests/test_multipass_decoding.py
@@ -1,0 +1,37 @@
+import pytest
+from utils import read_wav
+from demod import decode_full_period
+from tests.test_sample_wavs import DATA_DIR
+
+
+def unique(records):
+    seen = []
+    for rec in records:
+        dup = False
+        for s in seen:
+            if (
+                rec["message"] == s["message"]
+                and abs(rec["dt"] - s["dt"]) < 0.2
+                and abs(rec["freq"] - s["freq"]) < 1.0
+            ):
+                dup = True
+                break
+        if not dup:
+            seen.append(rec)
+    return seen
+
+
+@pytest.mark.parametrize(
+    "wav_rel",
+    ["191111_110130.wav", "20m_busy/test_02.wav"],
+)
+def test_multipass_recovers_additional(wav_rel):
+    wav_path = DATA_DIR / wav_rel
+    audio = read_wav(str(wav_path))
+    single_pass = unique(decode_full_period(audio, max_passes=1))
+    multi_pass = unique(decode_full_period(audio, max_passes=3))
+
+    # multi_pass should not contain duplicates
+    assert len(multi_pass) == len(set((r["message"], round(r["dt"], 1), round(r["freq"])) for r in multi_pass))
+
+    assert len(multi_pass) > len(single_pass)

--- a/tests/test_signal_subtraction.py
+++ b/tests/test_signal_subtraction.py
@@ -1,0 +1,26 @@
+import numpy as np
+
+from utils import RealSamples
+from utils.waveform import bits_to_tones, synth_waveform
+from search import candidate_score_map
+from tests.utils import default_search_params
+
+
+def test_score_reduction_after_subtraction():
+    sample_rate = 12000
+    total_len = int(15 * sample_rate)
+    bits = "0" * 174
+    tones = bits_to_tones(bits)
+    wave = synth_waveform(tones, sample_rate, 1500, 0.0, amplitude=1.0, total_len=total_len)
+
+    audio = RealSamples(wave.copy(), sample_rate)
+    max_freq_bin, max_dt_symbols = default_search_params(sample_rate)
+    scores, dts, freqs = candidate_score_map(audio, max_freq_bin, max_dt_symbols)
+    dt_idx = int(np.argmin(np.abs(dts - 0.0)))
+    freq_idx = int(np.argmin(np.abs(freqs - 1500)))
+    before = scores[dt_idx, freq_idx]
+
+    residual = RealSamples(audio.samples - wave, sample_rate)
+    scores_after, _, _ = candidate_score_map(residual, max_freq_bin, max_dt_symbols)
+    after = scores_after[dt_idx, freq_idx]
+    assert after < before * 0.1

--- a/utils/waveform.py
+++ b/utils/waveform.py
@@ -1,0 +1,79 @@
+import numpy as np
+
+from . import (
+    COSTAS_SEQUENCE,
+    COSTAS_START_OFFSET_SEC,
+    FT8_SYMBOL_LENGTH_IN_SEC,
+    FT8_SYMBOLS_PER_MESSAGE,
+    TONE_SPACING_IN_HZ,
+)
+
+# Gray-code map used for FT8 tone assignments
+_GRAY_MAP = [
+    0b000,
+    0b001,
+    0b011,
+    0b010,
+    0b110,
+    0b100,
+    0b101,
+    0b111,
+]
+
+# Pre-computed mapping from symbol index to Costas tone if the position is part
+# of one of the three 7-symbol sync sequences.
+_COSTAS_TONES = {i: t for i, t in zip(
+    list(range(7)) + list(range(36, 43)) + list(range(72, 79)),
+    COSTAS_SEQUENCE * 3,
+)}
+
+
+def bits_to_tones(bitstring: str) -> np.ndarray:
+    """Return the FT8 tone sequence encoded by ``bitstring``.
+
+    ``bitstring`` must contain the 174 FEC bits of an FT8 codeword.
+    """
+    if len(bitstring) != 174:
+        raise ValueError("bitstring must contain 174 bits")
+
+    tones = np.zeros(FT8_SYMBOLS_PER_MESSAGE, dtype=int)
+    bit_idx = 0
+    for sym in range(FT8_SYMBOLS_PER_MESSAGE):
+        if sym in _COSTAS_TONES:
+            tones[sym] = _COSTAS_TONES[sym]
+        else:
+            bits = bitstring[bit_idx : bit_idx + 3]
+            bit_idx += 3
+            val = int(bits, 2)
+            tones[sym] = _GRAY_MAP[val]
+    if bit_idx != len(bitstring):
+        raise ValueError("bitstring length mismatch")
+    return tones
+
+
+def synth_waveform(
+    tones: np.ndarray,
+    sample_rate: int,
+    base_freq: float,
+    start_sec: float,
+    amplitude: float = 1.0,
+    total_len: int | None = None,
+) -> np.ndarray:
+    """Return a real-valued waveform for ``tones`` starting at ``start_sec``."""
+    sym_len = int(round(sample_rate * FT8_SYMBOL_LENGTH_IN_SEC))
+    if total_len is None:
+        total_len = int(round(15.0 * sample_rate))
+    wave = np.zeros(total_len, dtype=float)
+
+    t = np.arange(sym_len) / sample_rate
+    base_start = int(round((start_sec + COSTAS_START_OFFSET_SEC) * sample_rate))
+    for i, tone in enumerate(tones):
+        freq = base_freq + tone * TONE_SPACING_IN_HZ
+        segment = amplitude * np.cos(2 * np.pi * freq * t)
+        start = base_start + i * sym_len
+        end = start + sym_len
+        if start >= total_len:
+            break
+        seg_end = min(end, total_len)
+        wave[start:seg_end] += segment[: seg_end - start]
+    return wave


### PR DESCRIPTION
## Summary
- split sample WAV tests into single-pass and multi-pass versions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687effa0b02c8327a5a74c93c9a635ea