### PR TITLE
feat(kiwi_ft8_monitor): add Kiwi FT8 console monitor, SNR column, strict oneshot alignment

### DIFF
--- a/apps/kiwi_ft8_monitor/README.md
+++ b/apps/kiwi_ft8_monitor/README.md
@@ -1,0 +1,40 @@
+Kiwi FT8 Monitor (console)
+
+This is a simple console application that connects to a KiwiSDR, streams audio
+at 12 kHz from a single receive channel (USB), chops the stream into 15‑second
+windows aligned to :00/:15/:30/:45 each minute, decodes FT8 with the local
+library, and displays results along with a small metrics panel.
+
+Requirements
+- Python 3.10+
+- This repository’s Python dependencies (install from repo root)
+- A KiwiSDR reachable at 192.168.2.10:8073 (default) with a free channel
+- The `kiwisdr` Python package for audio streaming:
+  - pip install kiwisdr
+
+Install Kiwi client locally (for one-shot/live via recorder)
+  bash apps/kiwi_ft8_monitor/install_kiwirecorder.sh
+
+Run (live monitor)
+  PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py \
+    --host 192.168.2.10 --freq-khz 14074 --mode usb --rate 12000
+
+One‑shot (connect, capture one 15 s window, decode, exit)
+  PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py \
+    --host 192.168.2.10 --freq-khz 14074 --mode usb --rate 12000 --oneshot --no-ui
+
+Offline test (use a WAV)
+  PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --wav ft8_lib-2.0/test/wav/websdr_test6.wav --no-ui
+
+Keys
+- q: quit
+
+Notes
+- The app aligns windows to UTC wall‑clock boundaries (:00/:15/:30/:45). Audio
+  is continuously buffered in a background reader, and decoding happens
+  immediately after each boundary using the last 15 seconds of buffered audio.
+- The metrics panel shows: candidate count (coarse search), decode count,
+  and decode wall time for the most recent window.
+ - For recorder-based capture, the app auto-detects a local binary at
+   apps/kiwi_ft8_monitor/bin/kiwirecorder.py (installed by the script),
+   or falls back to a kiwirecorder.py found on PATH.

--- a/apps/kiwi_ft8_monitor/bin/kiwirecorder.py
+++ b/apps/kiwi_ft8_monitor/bin/kiwirecorder.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$THIS_DIR/.." && pwd)"
+exec python3 "$APP_DIR/vendor/kiwiclient/kiwirecorder.py" "$@"

--- a/apps/kiwi_ft8_monitor/install_kiwirecorder.sh
+++ b/apps/kiwi_ft8_monitor/install_kiwirecorder.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install kiwirecorder locally under this app directory.
+# - Clones kiwiclient into vendor/
+# - Installs Python deps into current environment (use your venv)
+# - Creates bin/kiwirecorder.py wrapper
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$SCRIPT_DIR"
+VENDOR_DIR="$APP_DIR/vendor"
+BIN_DIR="$APP_DIR/bin"
+
+echo "[kiwirecorder] Installing under $APP_DIR"
+mkdir -p "$VENDOR_DIR" "$BIN_DIR"
+
+REPO_URL="https://github.com/jks-prv/kiwiclient.git"
+TARGET_DIR="$VENDOR_DIR/kiwiclient"
+
+if [[ -d "$TARGET_DIR/.git" ]]; then
+  echo "[kiwirecorder] Updating existing repo ..."
+  git -C "$TARGET_DIR" fetch --depth=1 origin
+  git -C "$TARGET_DIR" reset --hard origin/master
+else
+  echo "[kiwirecorder] Cloning $REPO_URL ..."
+  git clone --depth=1 "$REPO_URL" "$TARGET_DIR"
+fi
+
+REQ_FILE="$TARGET_DIR/requirements.txt"
+if [[ -f "$REQ_FILE" ]]; then
+  echo "[kiwirecorder] Installing Python requirements (use your venv) ..."
+  python3 -m pip install --upgrade pip >/dev/null
+  python3 -m pip install -r "$REQ_FILE"
+else
+  echo "[kiwirecorder] WARNING: requirements.txt not found; skipping pip install"
+fi
+
+WRAPPER="$BIN_DIR/kiwirecorder.py"
+cat > "$WRAPPER" << 'WRAP'
+#!/usr/bin/env bash
+set -euo pipefail
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$THIS_DIR/.." && pwd)"
+exec python3 "$APP_DIR/vendor/kiwiclient/kiwirecorder.py" "$@"
+WRAP
+chmod +x "$WRAPPER"
+
+echo "[kiwirecorder] Installed wrapper: $WRAPPER"
+echo "[kiwirecorder] Done. The app will auto-detect this local binary."
+


### PR DESCRIPTION
- Live monitor (recorder fallback): 15 s rolling windows, curses UI
- One-shot: aligned 15 s capture, timeouts/retries
- Offline: WAV processing for verification
- UI: UTC clock + 15 s progress bar, candidates/decodes/timing
- Sorting: decodes by ascending frequency
- SNR: print/UI column (uses rec['snr'] or 10*log10(score) fallback)
- Defaults: dial=14.074 MHz USB
- Installer: apps/kiwi_ft8_monitor/install_kiwirecorder.sh + local bin detection

If kiwisdr Python package is unavailable, app auto-falls back to local kiwirecorder.py for one-shot and live modes.
