### PR TITLE
build(setup): ensure venv uses Python >=3.11; support FT8R_PYTHON override

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ The setup script supports convenient flags:
 
 ### Python dependencies
 The venv installs the required Python packages listed in `requirements.txt`.
+
+Python version
+- The setup script selects the highest Python available that is ≥ 3.11 (tries `python3.13`, `python3.12`, `python3.11`, then `python3`/`python`).
+- Override with `FT8R_PYTHON` to force a specific interpreter:
+  - `FT8R_PYTHON=python3.12 ./scripts/setup_env.sh`
+  - `FT8R_PYTHON=/usr/bin/python3.11 ./scripts/setup_env.sh`
+- After activation (`source .venv/bin/activate`), `python --version` should report 3.11+.


### PR DESCRIPTION
Discover newest available Python (3.13/3.12/3.11 then python3/python)
Allow explicit override via FT8R_PYTHON and validate version
Use selected interpreter to create venv; log chosen version/path
Update README with usage examples and version notes