### PR TITLE
feat: SDRplay support for console FT8 monitor

### DIFF
--- a/apps/kiwi_ft8_monitor/README.md
+++ b/apps/kiwi_ft8_monitor/README.md
@@ -1,55 +1,57 @@
 FT8 Monitor (console)
 
-This is a simple console application that connects to a KiwiSDR, streams audio
-at 12 kHz from a single receive channel (USB), chops the stream into 15‑second
-windows aligned to :00/:15/:30/:45 each minute, decodes FT8 with the local
-library, and displays results along with a small metrics panel.
+This console app streams 12 kHz audio from either a KiwiSDR or an SDRplay RSP,
+aligns to 15‑second UTC boundaries (:00/:15/:30/:45), decodes FT8 using the
+local library, and shows results with a small metrics panel.
 
 Requirements
 - Python 3.10+
-- This repository’s Python dependencies (install from repo root)
+- Repo Python deps: from repo root run `python -m pip install -r requirements.txt`
+  (includes NumPy/SciPy/ldpc)
 - One of:
-  - KiwiSDR reachable at 192.168.2.10:8073 (default), or
-  - SDRplay RSP (tested with RSPduo) with SoapySDR + SDRplay API installed system-wide
+  - KiwiSDR reachable at 192.168.2.10:8073 (default). Optional: `pip install kiwisdr`
+    for direct streaming, or use the recorder fallback below.
+  - SDRplay RSP (tested with RSPduo) with:
+    - SoapySDR Python bindings available to Python
+    - SDRplay API/driver installed system‑wide
+    - SciPy (already in `requirements.txt`) for decimation
 
-Install Kiwi client locally (for one-shot/live via recorder)
+Optional: install Kiwi recorder locally (enables recorder fallback)
   bash apps/kiwi_ft8_monitor/install_kiwirecorder.sh
 
-Run (Kiwi live monitor)
+Usage
+- List SDRplay devices
+  PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --source sdrplay --list-sdrplay
+
+- Kiwi live monitor
   PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py \
     --source kiwi --host 192.168.2.10 --freq-khz 14074 --mode usb --rate 12000
 
-List SDRplay devices
-  PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --source sdrplay --list-sdrplay
-
-Run (SDRplay live monitor, choose by index)
+- SDRplay live (by index)
   PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py \
     --source sdrplay --device-index 0 --freq-khz 14074 --rate 12000 --sdr-rate 192000
 
-Run (SDRplay live monitor, explicit device args)
+- SDRplay live (by device args)
   PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py \
     --source sdrplay --device-args "driver=sdrplay,serial=YOUR_SERIAL" \
     --freq-khz 14074 --rate 12000 --sdr-rate 192000
 
-One‑shot (capture one 15 s, decode, exit)
+- Oneshot (capture one 15 s window, decode, exit)
   Kiwi:    PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --source kiwi --host 192.168.2.10 --freq-khz 14074 --mode usb --rate 12000 --oneshot --no-ui
   SDRplay: PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --source sdrplay --device-index 0 --freq-khz 14074 --rate 12000 --sdr-rate 192000 --oneshot --no-ui
 
-Offline test (use a WAV)
+- Offline (use a 12 kHz mono WAV)
   PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --wav ft8_lib-2.0/test/wav/websdr_test6.wav --no-ui
 
 Keys
 - q: quit
 
 Notes
-- The app aligns windows to UTC wall‑clock boundaries (:00/:15/:30/:45). Audio
-  is continuously buffered in a background reader, and decoding happens
-  immediately after each boundary using the last 15 seconds of buffered audio.
-- The metrics panel shows: candidate count (coarse search), decode count,
-  and decode wall time for the most recent window.
- - For recorder-based capture, the app auto-detects a local binary at
-   apps/kiwi_ft8_monitor/bin/kiwirecorder.py (installed by the script),
-   or falls back to a kiwirecorder.py found on PATH.
- - SDRplay mode uses a simple complex low‑pass + decimate and real extraction
-   to produce 12 kHz mono audio suitable for FT8 decoding. SoapySDR and the
-   SDRplay driver must be installed on the system.
+- Windows align to UTC boundaries. Audio is continuously buffered; decoding runs
+  immediately after each boundary over the last 15 seconds of audio.
+- Metrics panel shows: candidate count, decode count, and decode wall time for
+  the most recent window.
+- Recorder fallback: the app auto‑detects a local binary at
+  `apps/kiwi_ft8_monitor/bin/kiwirecorder.py` (installed by the script) or a
+  `kiwirecorder.py` found on PATH.
+- SDRplay path: complex IQ → low‑pass + decimate → real audio (USB demod) to 12 kHz.

--- a/apps/kiwi_ft8_monitor/README.md
+++ b/apps/kiwi_ft8_monitor/README.md
@@ -1,4 +1,4 @@
-Kiwi FT8 Monitor (console)
+FT8 Monitor (console)
 
 This is a simple console application that connects to a KiwiSDR, streams audio
 at 12 kHz from a single receive channel (USB), chops the stream into 15‑second
@@ -8,20 +8,32 @@ library, and displays results along with a small metrics panel.
 Requirements
 - Python 3.10+
 - This repository’s Python dependencies (install from repo root)
-- A KiwiSDR reachable at 192.168.2.10:8073 (default) with a free channel
-- The `kiwisdr` Python package for audio streaming:
-  - pip install kiwisdr
+- One of:
+  - KiwiSDR reachable at 192.168.2.10:8073 (default), or
+  - SDRplay RSP (tested with RSPduo) with SoapySDR + SDRplay API installed system-wide
 
 Install Kiwi client locally (for one-shot/live via recorder)
   bash apps/kiwi_ft8_monitor/install_kiwirecorder.sh
 
-Run (live monitor)
+Run (Kiwi live monitor)
   PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py \
-    --host 192.168.2.10 --freq-khz 14074 --mode usb --rate 12000
+    --source kiwi --host 192.168.2.10 --freq-khz 14074 --mode usb --rate 12000
 
-One‑shot (connect, capture one 15 s window, decode, exit)
+List SDRplay devices
+  PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --source sdrplay --list-sdrplay
+
+Run (SDRplay live monitor, choose by index)
   PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py \
-    --host 192.168.2.10 --freq-khz 14074 --mode usb --rate 12000 --oneshot --no-ui
+    --source sdrplay --device-index 0 --freq-khz 14074 --rate 12000 --sdr-rate 192000
+
+Run (SDRplay live monitor, explicit device args)
+  PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py \
+    --source sdrplay --device-args "driver=sdrplay,serial=YOUR_SERIAL" \
+    --freq-khz 14074 --rate 12000 --sdr-rate 192000
+
+One‑shot (capture one 15 s, decode, exit)
+  Kiwi:    PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --source kiwi --host 192.168.2.10 --freq-khz 14074 --mode usb --rate 12000 --oneshot --no-ui
+  SDRplay: PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --source sdrplay --device-index 0 --freq-khz 14074 --rate 12000 --sdr-rate 192000 --oneshot --no-ui
 
 Offline test (use a WAV)
   PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --wav ft8_lib-2.0/test/wav/websdr_test6.wav --no-ui
@@ -38,3 +50,6 @@ Notes
  - For recorder-based capture, the app auto-detects a local binary at
    apps/kiwi_ft8_monitor/bin/kiwirecorder.py (installed by the script),
    or falls back to a kiwirecorder.py found on PATH.
+ - SDRplay mode uses a simple complex low‑pass + decimate and real extraction
+   to produce 12 kHz mono audio suitable for FT8 decoding. SoapySDR and the
+   SDRplay driver must be installed on the system.

--- a/apps/kiwi_ft8_monitor/main.py
+++ b/apps/kiwi_ft8_monitor/main.py
@@ -69,7 +69,10 @@ class KiwiAudioSource:
                 if self._stop.is_set():
                     break
                 # Normalize chunk to python floats
-                self.buffer.extend(float(x) for x in chunk)
+                try:
+                    self.buffer.extend(chunk.astype(float, copy=False).tolist())
+                except Exception:
+                    self.buffer.extend(float(x) for x in chunk)
 
         self._thr = threading.Thread(target=_reader, daemon=True)
         self._thr.start()
@@ -82,6 +85,7 @@ class KiwiAudioSource:
             pass
         if self._thr is not None:
             self._thr.join(timeout=1.0)
+            self._thr = None
 
     def snapshot_last_15s(self) -> RealSamples:
         # Copy buffer atomically
@@ -221,7 +225,10 @@ class SdrplayAudioSource:
                 y = self._resample_poly(iq, up=1, down=dec, window=("kaiser", 8.6))
                 # Real mono audio
                 audio = np.real(y).astype(float)
-                self.buffer.extend(float(v) for v in audio)
+                try:
+                    self.buffer.extend(audio.tolist())
+                except Exception:
+                    self.buffer.extend(float(v) for v in audio)
 
         self._thr = threading.Thread(target=_reader, daemon=True)
         self._thr.start()
@@ -238,6 +245,7 @@ class SdrplayAudioSource:
             pass
         if self._thr is not None:
             self._thr.join(timeout=1.0)
+            self._thr = None
 
     def snapshot_last_15s(self) -> RealSamples:
         import numpy as np


### PR DESCRIPTION
This PR adds SDRplay (via SoapySDR) as a live audio source to the console FT8 monitor app alongside the existing KiwiSDR path.\n\nHighlights:\n- New SdrplayAudioSource using SoapySDR, simple USB demod (LPF+decim) to 12 kHz audio.\n- Oneshot mode for SDRplay and Kiwi.\n- Kiwi path supports fallback recorder-based monitoring using local or PATH kiwirecorder.py.\n- App README updated with setup, system dependencies, and usage examples.\n\nNotes:\n- No changes outside the app.\n- No tests added in this PR (follow-up PR can cover unit tests that avoid hardware dependencies).