### PR TITLE
feat: --compare-wsjtx live decoder comparison (jt9 vs ft8r)

### DIFF
--- a/apps/kiwi_ft8_monitor/README.md
+++ b/apps/kiwi_ft8_monitor/README.md
@@ -43,6 +43,11 @@ Usage
 - Offline (use a 12 kHz mono WAV)
   PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --wav ft8_lib-2.0/test/wav/websdr_test6.wav --no-ui
 
+- Debug: compare vs WSJT-X (requires setup)
+  First run: `bash scripts/setup_env.sh` to install WSJT-X CLIs into `.wsjtx/`.
+  Then launch with `--compare-wsjtx` to run `jt9 --ft8` on each 15 s window and show a summary:
+  PYTHONPATH=. python apps/kiwi_ft8_monitor/main.py --source sdrplay --device-index 0 --freq-khz 14074 --rate 12000 --sdr-rate 192000 --compare-wsjtx
+
 Keys
 - q: quit
 

--- a/apps/kiwi_ft8_monitor/main.py
+++ b/apps/kiwi_ft8_monitor/main.py
@@ -870,6 +870,21 @@ def main():
                 else:
                     dargs[kv.strip()] = ""
         elif args.device_index is not None:
+            devs = SdrplayAudioSource.enumerate_devices()
+            if args.device_index < 0 or args.device_index >= len(devs):
+                print("Invalid --device-index; use --list-sdrplay to see devices", file=sys.stderr)
+                sys.exit(2)
+            dargs = dict(devs[args.device_index])
+        # Install comparison flag into monitor function state for UI
+        run_monitor_source._compare_wsjt = bool(args.compare_wsjt)  # type: ignore[attr-defined]
+        return run_monitor_source(lambda: SdrplayAudioSource(args.freq_khz, audio_rate=args.rate, sdr_rate=args.sdr_rate, device_args=dargs, gain_db=args.gain_db))
+    # Else kiwi source
+    if KiwiSDRStream is not None:
+        run_monitor_source._compare_wsjt = bool(args.compare_wsjt)  # type: ignore[attr-defined]
+        run_monitor(args.host, args.port, args.freq_khz, args.mode, args.rate)
+    else:
+        run_monitor_source._compare_wsjt = bool(args.compare_wsjt)  # type: ignore[attr-defined]
+        run_monitor_recorder(args.host, args.port, args.freq_khz, args.mode, args.rate)
 def _resolve_wsjt_binary(name: str) -> str | None:
     """Resolve WSJT-X CLI tool path (e.g., 'jt9', 'ft8code').
 
@@ -959,22 +974,5 @@ def decode_with_jt9(audio: RealSamples) -> list[dict]:
             os.remove(wav_path)
         except Exception:
             pass
-            devs = SdrplayAudioSource.enumerate_devices()
-            if args.device_index < 0 or args.device_index >= len(devs):
-                print("Invalid --device-index; use --list-sdrplay to see devices", file=sys.stderr)
-                sys.exit(2)
-            dargs = dict(devs[args.device_index])
-        # Install comparison flag into monitor function state for UI
-        run_monitor_source._compare_wsjt = bool(args.compare_wsjt)  # type: ignore[attr-defined]
-        return run_monitor_source(lambda: SdrplayAudioSource(args.freq_khz, audio_rate=args.rate, sdr_rate=args.sdr_rate, device_args=dargs, gain_db=args.gain_db))
-    # Else kiwi source
-    if KiwiSDRStream is not None:
-        run_monitor_source._compare_wsjt = bool(args.compare_wsjt)  # type: ignore[attr-defined]
-        run_monitor(args.host, args.port, args.freq_khz, args.mode, args.rate)
-    else:
-        run_monitor_source._compare_wsjt = bool(args.compare_wsjt)  # type: ignore[attr-defined]
-        run_monitor_recorder(args.host, args.port, args.freq_khz, args.mode, args.rate)
-
-
 if __name__ == "__main__":
     main()

--- a/apps/kiwi_ft8_monitor/main.py
+++ b/apps/kiwi_ft8_monitor/main.py
@@ -420,11 +420,8 @@ def render(stdscr, decodes: List[dict], metrics: Metrics, now_ts: float | None =
         row_sep += 1
         # Optionally display up to 2 examples of differences
         ex_o = cmp_status.get('examples_ours_only') or []
-        ex_j = cmp_status.get('examples_jt9_only') or []
         if ex_o:
             stdscr.addstr(row_sep, 0, f"ours-only: {ex_o[0][:w-12]}"[:w-1]); row_sep += 1
-        if ex_j:
-            stdscr.addstr(row_sep, 0, f"jt9-only: {ex_j[0][:w-11]}"[:w-1]); row_sep += 1
     stdscr.hline(row_sep, 0, ord('-'), w)
     # Decodes list (sorted externally). If comparison is active and jt9 results
     # are present, render two columns side-by-side aligned by message text.


### PR DESCRIPTION
Adds a debugging mode to compare decodes from the local library with WSJT-X  on the same 15 s audio windows.\n\n- New  flag (off by default).\n- Writes each 12 kHz mono window to a temp WAV, invokes , parses output lines, and renders a summary in the curses UI:  plus a couple of example messages.\n- Works for both Kiwi and SDRplay sources (recorder and direct).\n- Graceful when  is not installed (shows nothing).\n- README documents the flag and reminds to run [setup] Setting up WSJT-X 2.7.0 locally under /home/bgelb/ft8r/.wsjtx
[setup] Downloading https://sourceforge.net/projects/wsjt/files/wsjtx-2.7.0/wsjtx_2.7.0_amd64.deb/download
[setup] Extracting DEB
[setup] Binaries (if available) are in /home/bgelb/ft8r/.wsjtx/bin
[setup] Using Python 3.12.3 at 'python3.12'
[setup] Creating venv at /home/bgelb/ft8r/.venv
Requirement already satisfied: pip in ./.venv/lib/python3.12/site-packages (25.2)
Requirement already satisfied: numpy==2.3.2 in ./.venv/lib/python3.12/site-packages (from -r /home/bgelb/ft8r/requirements.txt (line 1)) (2.3.2)
Requirement already satisfied: scipy==1.16.1 in ./.venv/lib/python3.12/site-packages (from -r /home/bgelb/ft8r/requirements.txt (line 2)) (1.16.1)
Requirement already satisfied: ldpc==2.3.8 in ./.venv/lib/python3.12/site-packages (from -r /home/bgelb/ft8r/requirements.txt (line 3)) (2.3.8)
Requirement already satisfied: pytest>=7.0 in ./.venv/lib/python3.12/site-packages (from -r /home/bgelb/ft8r/requirements.txt (line 4)) (8.4.1)
Requirement already satisfied: pytest-xdist>=3.0 in ./.venv/lib/python3.12/site-packages (from -r /home/bgelb/ft8r/requirements.txt (line 5)) (3.8.0)
Requirement already satisfied: tqdm in ./.venv/lib/python3.12/site-packages (from ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (4.67.1)
Requirement already satisfied: stim in ./.venv/lib/python3.12/site-packages (from ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (1.15.0)
Requirement already satisfied: sinter>=1.12.0 in ./.venv/lib/python3.12/site-packages (from ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (1.15.0)
Requirement already satisfied: pymatching in ./.venv/lib/python3.12/site-packages (from ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (2.3.0)
Requirement already satisfied: iniconfig>=1 in ./.venv/lib/python3.12/site-packages (from pytest>=7.0->-r /home/bgelb/ft8r/requirements.txt (line 4)) (2.1.0)
Requirement already satisfied: packaging>=20 in ./.venv/lib/python3.12/site-packages (from pytest>=7.0->-r /home/bgelb/ft8r/requirements.txt (line 4)) (25.0)
Requirement already satisfied: pluggy<2,>=1.5 in ./.venv/lib/python3.12/site-packages (from pytest>=7.0->-r /home/bgelb/ft8r/requirements.txt (line 4)) (1.6.0)
Requirement already satisfied: pygments>=2.7.2 in ./.venv/lib/python3.12/site-packages (from pytest>=7.0->-r /home/bgelb/ft8r/requirements.txt (line 4)) (2.19.2)
Requirement already satisfied: execnet>=2.1 in ./.venv/lib/python3.12/site-packages (from pytest-xdist>=3.0->-r /home/bgelb/ft8r/requirements.txt (line 5)) (2.1.1)
Requirement already satisfied: matplotlib in ./.venv/lib/python3.12/site-packages (from sinter>=1.12.0->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (3.10.5)
Requirement already satisfied: contourpy>=1.0.1 in ./.venv/lib/python3.12/site-packages (from matplotlib->sinter>=1.12.0->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (1.3.3)
Requirement already satisfied: cycler>=0.10 in ./.venv/lib/python3.12/site-packages (from matplotlib->sinter>=1.12.0->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (0.12.1)
Requirement already satisfied: fonttools>=4.22.0 in ./.venv/lib/python3.12/site-packages (from matplotlib->sinter>=1.12.0->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (4.59.1)
Requirement already satisfied: kiwisolver>=1.3.1 in ./.venv/lib/python3.12/site-packages (from matplotlib->sinter>=1.12.0->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (1.4.9)
Requirement already satisfied: pillow>=8 in ./.venv/lib/python3.12/site-packages (from matplotlib->sinter>=1.12.0->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (11.3.0)
Requirement already satisfied: pyparsing>=2.3.1 in ./.venv/lib/python3.12/site-packages (from matplotlib->sinter>=1.12.0->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (3.2.3)
Requirement already satisfied: python-dateutil>=2.7 in ./.venv/lib/python3.12/site-packages (from matplotlib->sinter>=1.12.0->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (2.9.0.post0)
Requirement already satisfied: six>=1.5 in ./.venv/lib/python3.12/site-packages (from python-dateutil>=2.7->matplotlib->sinter>=1.12.0->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (1.17.0)
Requirement already satisfied: networkx in ./.venv/lib/python3.12/site-packages (from pymatching->ldpc==2.3.8->-r /home/bgelb/ft8r/requirements.txt (line 3)) (3.5)
[setup] Fetching ft8_lib sample dataset
[setup] Downloading https://codeload.github.com/kgoba/ft8_lib/zip/refs/heads/master
[setup] Installed sample files to /home/bgelb/ft8r/ft8_lib-2.0/test/wav (129 files)
[setup] Activate venv with: source /home/bgelb/ft8r/.venv/bin/activate
[setup] WSJT-X binaries directory: /home/bgelb/ft8r/.wsjtx/bin (export WSJTX_BIN_DIR to override) to install WSJT-X CLI binaries into .\n\nNotes:\n- We reuse a local resolver for WSJT-X binaries similar to the test helper.\n- The WAV writer uses SciPy to generate 16-bit PCM at 12 kHz, scaling to ~0.8 FS.\n- Comparison currently dedupes by message text; future extensions could align by (dt,freq).