### PR TITLE
feat: suppress nearby duplicate decodes

### DIFF
--- a/tests/test_sample_wavs_short.py
+++ b/tests/test_sample_wavs_short.py
@@ -8,6 +8,7 @@ from tests.test_sample_wavs import (
     parse_expected,
     list_all_stems,
     _strict_eps,
+    assert_no_unexpected_duplicates,
 )
 
 
@@ -51,6 +52,7 @@ def test_decode_sample_wavs_short_aggregate(ft8r_metrics):
 
         audio = read_wav(str(wav_path))
         results = decode_full_period(audio, include_bits=True)
+        assert_no_unexpected_duplicates(results)
         raw_decodes += len(results)
         hard_crc_total += sum(1 for r in results if r.get("method") == "hard")
         # Deduplicate by payload bits; store corresponding text


### PR DESCRIPTION
## Summary
- group decoded FT8 messages with identical payloads that are within 1 tone bin and 1 symbol period
- keep the decode with the strongest |LLR| from each group

## Testing
- `pytest tests/test_sample_wavs_short.py::test_decode_sample_wavs_short_aggregate -q -o addopts=`
- `pytest tests/test_sample_wavs.py::test_decode_sample_wavs_aggregate -q -o addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68b66133c95c83279f1c691a6ee4f781