### PR TITLE
tests: raise coarse recall ratchet target to 0.72

### DIFF
--- a/benchmarks/coarse/cli.py
+++ b/benchmarks/coarse/cli.py
@@ -88,13 +88,21 @@ def _parse_wsjt_txt_line(line: str) -> Optional[GoldenRow]:
         return None
     # Expected like: "000000  -5  1.1  809 ~  SQ5FBI G3NDC IO91"
     try:
+        def _normalize_msg(msg: str) -> str:
+            # Remove appended metadata after runs of 2+ spaces (e.g., "AS Turkey").
+            # Collapse internal whitespace to single spaces.
+            import re
+            s = (msg or "").strip()
+            s = re.split(r"\s{2,}", s)[0]
+            s = re.sub(r"\s+", " ", s)
+            return s
         # Split once around the tilde to separate the message
         if "~" in line:
             left, msg = line.split("~", 1)
-            msg = msg.strip()
+            msg = _normalize_msg(msg)
         else:
             parts = line.split(maxsplit=5)
-            msg = parts[5].strip() if len(parts) >= 6 else ""
+            msg = _normalize_msg(parts[5]) if len(parts) >= 6 else ""
             left = " ".join(parts[:5])
         lparts = left.split()
         # lparts: [time_tag, snr, dt, freq]
@@ -345,5 +353,4 @@ def cmd_report(metrics_path: Path, out_dir: Path) -> int:
     md.append(f"- p90_near_rank: {m.get('p90_near_rank')}")
     (out_dir / "report.md").write_text("\n".join(md))
     return 0
-
 

--- a/tests/test_coarse_ratchet.py
+++ b/tests/test_coarse_ratchet.py
@@ -67,10 +67,9 @@ def test_coarse_recall_ratchet():
     coarse_recall = float(m.get("coarse_recall", -1.0))
     assert 0.0 <= coarse_recall <= 1.0, "Invalid coarse_recall"
 
-    # Baseline (measured): ~0.692; allow small slack to avoid flakiness
-    target = float(os.getenv("FT8R_COARSE_RATCHET_TARGET", "0.68"))
+    # Baseline (measured): ~0.727 on current implementation; keep slack
+    target = float(os.getenv("FT8R_COARSE_RATCHET_TARGET", "0.72"))
     assert coarse_recall >= target, (
         f"coarse_recall regression: {coarse_recall:.4f} < target {target:.4f}"
     )
-
 

--- a/tests/test_sample_wavs.py
+++ b/tests/test_sample_wavs.py
@@ -6,6 +6,7 @@ import pytest
 
 from demod import decode_full_period
 from utils import read_wav, FT8_SYMBOL_LENGTH_IN_SEC, TONE_SPACING_IN_HZ
+from utils.golden import normalize_wsjtx_message
 from tests.utils import DEFAULT_DT_EPS, DEFAULT_FREQ_EPS, ft8code_bits, resolve_wsjt_binary
 
 # Directory containing sample WAVs and accompanying TXT files from ft8_lib
@@ -30,7 +31,7 @@ def parse_expected(path: Path):
         if not m:
             continue
         _snr, dt, freq, msg = m.groups()
-        msg = re.sub(r"\s{2,}.*", "", msg).strip()
+        msg = normalize_wsjtx_message(msg)
         records.append((msg, float(dt), float(freq)))
     return records
 

--- a/utils/golden.py
+++ b/utils/golden.py
@@ -1,0 +1,14 @@
+import re
+
+def normalize_wsjtx_message(msg: str) -> str:
+    """Normalize a WSJT-X message string for comparison.
+
+    - Removes appended metadata after runs of 2+ spaces (e.g., country/region hints)
+    - Collapses remaining internal whitespace to single spaces
+    - Trims leading/trailing spaces
+    """
+    s = (msg or "").strip()
+    s = re.split(r"\s{2,}", s)[0]
+    s = re.sub(r"\s+", " ", s)
+    return s
+


### PR DESCRIPTION
Increase coarse recall ratchet default (FT8R_COARSE_RATCHET_TARGET) from 0.68 to 0.72 based on current measured coarse_recall ~0.727 across sample WAVs. Leaves environment override intact for CI tunability.