### PR TITLE
Align docs with code defaults and prune stale comments

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -20,10 +20,13 @@ The decoder processes one 15‑second FT8 cycle of mono PCM audio and returns al
 - File: `search.py`
 - Key functions:
   - `candidate_score_map(samples_in, max_freq_bin, max_dt_in_symbols)`
+  - `budget_tile_candidates(scores, dts, freqs, threshold, budget)`
   - `peak_candidates(scores, dts, freqs, threshold)`
   - `find_candidates(samples_in, max_freq_bin, max_dt_in_symbols, threshold)`
 
 The input audio is evaluated over a time/frequency grid using short FFTs at an oversampling ratio in time and frequency. A Costas‑sequence kernel identifies likely FT8 starts via a Costas power ratio (active bins vs. unused Costas bins), and local maxima above `threshold` are returned as `(score, dt, base_freq)` candidates.
+
+`find_candidates` selects peaks either by a global per‑tile budget (`budget_tile_candidates`, default via `FT8R_COARSE_MODE=budget`) or by simple local maxima (`peak_candidates` when `FT8R_COARSE_MODE=peak`).
 
 #### Narrow‑band baseband extraction
 
@@ -68,7 +71,7 @@ LLRs are converted into per‑bit error probabilities (with reliability scaling)
 - File: `demod.py`
 - Key function: `decode_full_period(samples_in, threshold)`
 
-Calls the candidate search, applies refined (quadratic) fine synchronization, demodulates, LDPC‑decodes, and text‑decodes each valid message. Each successful decode returns a dictionary with `message`, `score`, `freq`, and `dt`.
+Calls the candidate search, applies refined (quadratic) fine synchronization, performs a light frequency microsearch on CRC failure, demodulates, LDPC‑decodes, and text‑decodes each valid message. Each successful decode returns a dictionary with `message`, `score`, `freq`, `dt`, and the decode `method` (`hard` or `ldpc`).
 
 ### Performance tuning and profiling
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,12 @@ This repository explores building an FT8 demodulator. The test suite can run ful
 
 Optional runtime features (env toggles):
 - Coarse whitening (improves contrast in busy bands)
-  - `FT8R_WHITEN_ENABLE=1` to enable
-  - `FT8R_WHITEN_MODE=global|tile` (default `global`); `tile` uses robust per‑tile scaling (median + α·MAD)
+  - Enabled by default; set `FT8R_WHITEN_ENABLE=0` to disable
+  - `FT8R_WHITEN_MODE=tile|global` (default `tile`); `tile` uses robust per‑tile scaling (median + α·MAD)
 - Coarse candidate selection
-  - `FT8R_COARSE_MODE=peak|budget` (default `peak`); `budget` distributes picks per tile up to `FT8R_MAX_CANDIDATES`
+  - `FT8R_COARSE_MODE=budget|peak` (default `budget`); `budget` distributes picks per tile up to `FT8R_MAX_CANDIDATES`
 - Light microsearch (single‑pass; small frequency nudges on CRC failure)
-  - `FT8R_MICRO_LIGHT_ENABLE=1` to enable
-  - `FT8R_MICRO_LIGHT_DF_SPAN` (default `1.0` Hz), `FT8R_MICRO_LIGHT_DF_STEP` (default `0.5` Hz)
+  - Configured via `FT8R_MICRO_LIGHT_DF_SPAN` (default `1.0` Hz) and `FT8R_MICRO_LIGHT_DF_STEP` (default `0.5` Hz)
 
 ### Quick start
 

--- a/demod.py
+++ b/demod.py
@@ -80,11 +80,8 @@ _ENV_MAX = os.getenv("FT8R_MAX_CANDIDATES", "").strip()
 # Default cap chosen from empirical candidate distribution (p99≈1244, max≈1260)
 # across bundled samples, with headroom. Set to 0 to disable capping.
 _MAX_CANDIDATES = 1500 if _ENV_MAX == "" else int(_ENV_MAX)
-# Legacy alignment path removed.
 # Allow bypassing CRC gating for troubleshooting only. Defaults to disabled.
 _ALLOW_CRC_FAIL = os.getenv("FT8R_ALLOW_CRC_FAIL", "0") not in ("0", "", "false", "False")
-# Column reordering around LDPC is not used; H columns match transmitted order.
-# Optional debug: include raw decoded bits and parity/CRC flags in results
 # Offset of the band edges relative to ``freq`` expressed in tone spacings.
 # ``freq`` corresponds to tone 0 so the bottom edge lies 1.5 tone spacings
 # below it and the top edge is ``SLICE_SPAN_TONES - 1.5`` spacings above.
@@ -613,7 +610,5 @@ def decode_full_period(samples_in: RealSamples, threshold: float = 1.0, *, inclu
             decoded_any = True
         except Exception:
             decoded_any = False
-
-        # Legacy alignment removed
 
     return _dedup_decodes(results)

--- a/search.py
+++ b/search.py
@@ -152,10 +152,10 @@ def candidate_score_map(
         fft_pwr = np.abs(ffts) ** 2
 
     # Optional local whitening/normalization to improve contrast in busy bands.
-    # Enable via FT8R_WHITEN_ENABLE (1 to enable)
+    # Enabled by default; disable via FT8R_WHITEN_ENABLE=0
     if os.getenv("FT8R_WHITEN_ENABLE", "1") not in ("0", "", "false", "False"):
         eps = float(os.getenv("FT8R_WHITEN_EPS", "1e-12"))
-        # Mode: 'tile' or 'global' via FT8R_WHITEN_MODE
+        # Mode: 'tile' or 'global' via FT8R_WHITEN_MODE (default 'tile')
         mode = os.getenv("FT8R_WHITEN_MODE", "tile").strip().lower()
         if mode == "tile":
             # Robust local scaling via non-overlapping tiles:

--- a/tests/test_candidate_search.py
+++ b/tests/test_candidate_search.py
@@ -1,5 +1,6 @@
 from search import find_candidates, candidate_score_map, peak_candidates
 import numpy as np
+import os
 from utils import (
     read_wav,
     RealSamples,
@@ -111,8 +112,12 @@ def test_candidate_peak_filter(tmp_path):
     assert abs(dt - 0.0) < DEFAULT_DT_EPS
     assert score > DEFAULT_SEARCH_THRESHOLD
 
-    # ``find_candidates`` should yield the same result via ``peak_candidates``
-    via_api = find_candidates(
-        audio, max_freq_bin, max_dt_symbols, threshold=thresh
-    )
+    # ``find_candidates`` should yield the same result when mode='peak'
+    os.environ["FT8R_COARSE_MODE"] = "peak"
+    try:
+        via_api = find_candidates(
+            audio, max_freq_bin, max_dt_symbols, threshold=thresh
+        )
+    finally:
+        os.environ.pop("FT8R_COARSE_MODE", None)
     assert via_api == peaks


### PR DESCRIPTION
## Summary
- Document actual defaults for whitening, candidate budgeting, and microsearch
- Mention tile-budget candidate search and microsearch in architecture overview
- Remove outdated legacy/debug comments and clean up candidate search test

## Testing
- `FT8R_COARSE_MODE=budget pytest -q -o addopts=''`


------
https://chatgpt.com/codex/tasks/task_e_68b6715e93288327b4f62c791b177d3c