### PR TITLE
demod: remove unused early |LLR| gate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -108,10 +108,7 @@ All changes preserve numerical results; any behavior differences can be gated vi
 
 The legacy alignment toggles have been removed.
 
-- `FT8R_MIN_LLR_AVG` (default: `0.0` = disabled)
-  - If set to a positive float, performs an early reject when average |LLR| for a candidate is below this threshold, skipping LDPC. Trade‑off: can significantly reduce LDPC workload but risks dropping very weak decodes if set too high. Recommended only for latency‑critical deployments after tuning on your signal set.
-
-Additional flags used in CI/testing:
+- Additional flags used in CI/testing:
 
 - `FT8R_PERF`, `FT8R_PERF_STEM`, `FT8R_PERF_REPEATS`, `FT8R_TARGET_S`, `FT8R_PERF_ALLOW_FAIL` control the opt‑in performance test.
 


### PR DESCRIPTION
Remove the early-reject by average |LLR| code path, which has been effectively disabled (forced to 0.0) and unused in production.\n\n- Simplifies decode_full_period by dropping the low-LLR short-circuit.\n- Keeps mean |LLR| for diagnostics only.\n- Updates ARCHITECTURE.md to remove the FT8R_MIN_LLR_AVG knob.\n- No changes to tests or decode behavior expected.