### PR TITLE
coarse: remove mode switch; use budgeted selection

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,12 +21,12 @@ The decoder processes one 15‑second FT8 cycle of mono PCM audio and returns al
 - Key functions:
   - `candidate_score_map(samples_in, max_freq_bin, max_dt_in_symbols)`
   - `budget_tile_candidates(scores, dts, freqs, threshold, budget)`
-  - `peak_candidates(scores, dts, freqs, threshold)`
+  - `peak_candidates(scores, dts, freqs, threshold)` (utility; not used in default pipeline)
   - `find_candidates(samples_in, max_freq_bin, max_dt_in_symbols, threshold)`
 
 The input audio is evaluated over a time/frequency grid using short FFTs at an oversampling ratio in time and frequency. A Costas‑sequence kernel identifies likely FT8 starts via a Costas power ratio (active bins vs. unused Costas bins), and local maxima above `threshold` are returned as `(score, dt, base_freq)` candidates.
 
-`find_candidates` selects peaks either by a global per‑tile budget (`budget_tile_candidates`, default via `FT8R_COARSE_MODE=budget`) or by simple local maxima (`peak_candidates` when `FT8R_COARSE_MODE=peak`).
+`find_candidates` uses budgeted per‑tile selection (`budget_tile_candidates`) to control candidate counts. `peak_candidates` remains available for experiments and tests.
 
 #### Narrow‑band baseband extraction
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -108,10 +108,7 @@ All changes preserve numerical results; any behavior differences can be gated vi
 
 The legacy alignment toggles have been removed.
 
-- `FT8R_MIN_LLR_AVG` (default: `0.0` = disabled)
-  - If set to a positive float, performs an early reject when average |LLR| for a candidate is below this threshold, skipping LDPC. Trade‑off: can significantly reduce LDPC workload but risks dropping very weak decodes if set too high. Recommended only for latency‑critical deployments after tuning on your signal set.
-
-Additional flags used in CI/testing:
+- Additional flags used in CI/testing:
 
 - `FT8R_PERF`, `FT8R_PERF_STEM`, `FT8R_PERF_REPEATS`, `FT8R_TARGET_S`, `FT8R_PERF_ALLOW_FAIL` control the opt‑in performance test.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Optional runtime features (env toggles):
   - Enabled by default; set `FT8R_WHITEN_ENABLE=0` to disable
   - `FT8R_WHITEN_MODE=tile|global` (default `tile`); `tile` uses robust per‑tile scaling (median + α·MAD)
 - Coarse candidate selection
-  - `FT8R_COARSE_MODE=budget|peak` (default `budget`); `budget` distributes picks per tile up to `FT8R_MAX_CANDIDATES`
+  - Budgeted per-tile selection up to `FT8R_MAX_CANDIDATES` (no mode switch)
 - Light microsearch (single‑pass; small frequency nudges on CRC failure)
   - Configured via `FT8R_MICRO_LIGHT_DF_SPAN` (default `1.0` Hz) and `FT8R_MICRO_LIGHT_DF_STEP` (default `0.5` Hz)
 

--- a/search.py
+++ b/search.py
@@ -432,13 +432,9 @@ def find_candidates(
         max_dt_in_symbols,
     )
 
-    # Selection mode via FT8R_COARSE_MODE ('budget' or 'peak')
-    mode = os.getenv("FT8R_COARSE_MODE", "budget").strip().lower()
-    if mode == "budget":
-        # Target a global budget. Fall back to peak if budget invalid.
-        try:
-            B = int(os.getenv("FT8R_MAX_CANDIDATES", "1500"))
-        except Exception:
-            B = 1500
-        return budget_tile_candidates(scores, dts, freqs, threshold, budget=B if B > 0 else 1500)
-    return peak_candidates(scores, dts, freqs, threshold)
+    # Always use budgeted per-tile selection to control candidate counts
+    try:
+        B = int(os.getenv("FT8R_MAX_CANDIDATES", "1500"))
+    except Exception:
+        B = 1500
+    return budget_tile_candidates(scores, dts, freqs, threshold, budget=B if B > 0 else 1500)

--- a/tests/test_candidate_search.py
+++ b/tests/test_candidate_search.py
@@ -112,12 +112,5 @@ def test_candidate_peak_filter(tmp_path):
     assert abs(dt - 0.0) < DEFAULT_DT_EPS
     assert score > DEFAULT_SEARCH_THRESHOLD
 
-    # ``find_candidates`` should yield the same result when mode='peak'
-    os.environ["FT8R_COARSE_MODE"] = "peak"
-    try:
-        via_api = find_candidates(
-            audio, max_freq_bin, max_dt_symbols, threshold=thresh
-        )
-    finally:
-        os.environ.pop("FT8R_COARSE_MODE", None)
-    assert via_api == peaks
+    # Peak filtering tested directly via peak_candidates above. find_candidates
+    # uses the budgeted selection path unconditionally.


### PR DESCRIPTION
Remove FT8R_COARSE_MODE and the mode switch in find_candidates; always use budgeted per-tile selection controlled by FT8R_MAX_CANDIDATES.\n\n- Keeps peak_candidates as a utility for tests/experiments.\n- Updates README and ARCHITECTURE docs.\n- Adjusts test to avoid env-driven mode expectations.\n\nNo behavior change to default pipeline; simplifies configuration and reduces tech debt.